### PR TITLE
Add template CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# In all these entries, it's OK to leave all 3 groups listed regardless of which
+# org the new repo will be in. GitHub automatically applies the correct version.
+
+# Uncomment the appropriate team line to automatically tag the owning team on PRs
+# * @cyberark/community-and-integrations-team @conjurinc/community-and-integrations-team @conjurdemos/community-and-integrations-team
+# * @cyberark/conjur-core-team @conjurinc/conjur-core-team @conjurdemos/conjur-core-team
+
+# Changes to .trivyignore require Security Architect approval
+.trivyignore @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects
+
+# Changes to .codeclimate.yml require Quality Architect approval
+.codeclimate.yml @cyberark/quality-architects @conjurinc/quality-architects @conjurdemos/quality-architects


### PR DESCRIPTION
Adds CODEOWNERS file to automatically make .trivyignore and .codeclimate.yml files require review from appropriate teams. Also adds lines that can be uncommented to add the main engineering team for the repo to all PRs.

Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>