### PR TITLE
Add "new project" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-project.md
+++ b/.github/ISSUE_TEMPLATE/new-project.md
@@ -1,0 +1,20 @@
+---
+name: New project
+about: Request that a new project be created from this template repository
+title: ''
+labels: kind/new-project
+assignees: ''
+
+---
+
+## Request for a new public Conjur project in CyberArk GitHub
+
+Current project source: {GitHub URL}
+
+Current maintainer: {First and Last Name}, {GitHub username}
+
+Desired project URL: https://github.com/cyberark/{project-title}
+
+Brief description of project:
+
+Anticipated [certification level](https://github.com/cyberark/community/blob/master/Conjur/conventions/certification-levels.md): Community/Trusted/Certified

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,7 @@
 
 #### Important
 - [ ] If this repo will be public, also follow these [requirements](https://github.com/cyberark/employee-guidelines/blob/master/guidelines/public_repos_checklist.md)
+- [ ] Remove the "new project" issue template from the project: `.github/ISSUE_TEMPLATE/new-project.md`
 - [ ] (Final TODO) **Delete this checklist from the PR template** (in `.github/pull_request_template.md`)
   
 ---


### PR DESCRIPTION
This can be used to file issues in this repository to create new projects
based on this template.

When someone creates an issue in this project, and they choose the "new project" template, they're given a form to fill out with info on their project. We can track these requests publicly so it is clear to community members which projects are moving forward, and their statuses.