### PR TITLE
Add SECURITY.md to all projects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,5 +8,8 @@
 # Changes to .trivyignore require Security Architect approval
 .trivyignore @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects
 
+# Changes to SECURITY.md require Security Architect approval
+SECURITY.md @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects
+
 # Changes to .codeclimate.yml require Quality Architect approval
 .codeclimate.yml @cyberark/quality-architects @conjurinc/quality-architects @conjurdemos/quality-architects

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policies and Procedures
+
+This document outlines security procedures and general policies for the CyberArk Conjur
+suite of tools and products.
+
+  * [Reporting a Bug](#reporting-a-bug)
+  * [Disclosure Policy](#disclosure-policy)
+  * [Comments on this Policy](#comments-on-this-policy)
+
+## Reporting a Bug
+
+The CyberArk Conjur team and community take all security bugs in the Conjur suite seriously.
+Thank you for improving the security of the Conjur suite. We appreciate your efforts and
+responsible disclosure and will make every effort to acknowledge your
+contributions.
+
+Report security bugs by emailing the lead maintainers at security@conjur.org.
+
+The maintainers will acknowledge your email within 2 business days. Subsequently, we will 
+send a more detailed response within 2 business days of our acknowledgement indicating
+the next steps in handling your report. After the initial reply to your report, the security
+team will endeavor to keep you informed of the progress towards a fix and full
+announcement, and may ask for additional information or guidance.
+
+Report security bugs in third-party modules to the person or team maintaining
+the module.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it to a
+primary handler. This person will coordinate the fix and release process,
+involving the following steps:
+
+  * Confirm the problem and determine the affected versions.
+  * Audit code to find any potential similar problems.
+  * Prepare fixes for all releases still under maintenance. These fixes will be
+    released as fast as possible.
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved please submit a
+pull request.


### PR DESCRIPTION
This PR adds a SECURITY.md that will be added to all new and existing projects, so that our current security policy will be published in all of our relevant repos.